### PR TITLE
Fix GPG keys

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,8 +1,13 @@
 ---
-- name: Add packagecloud GPG key.
+- name: Add GPG keys.
   rpm_key:
-    key: "https://packagecloud.io/gpg.key"
+    key: "{{ item }}"
     state: present
+  with_items:
+    - "https://packagecloud.io/gpg.key"
+    - "https://packagecloud.io/rabbitmq/erlang/gpgkey"
+    - "https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey"
+    - "https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc"
 
 - name: Download RabbitMQ package.
   get_url:


### PR DESCRIPTION
This is the solution by @mkondratev, copied from https://github.com/geerlingguy/ansible-role-rabbitmq/pull/14.

It fixes the error `Failed to validate GPG signature for rabbitmq-server-3.8.16-1.el8.noarch` on my Rocky 8 machine.